### PR TITLE
Fixed log_spaced_frequencies() function

### DIFF
--- a/analytic_wavelet/generalized_morse_wavelet.py
+++ b/analytic_wavelet/generalized_morse_wavelet.py
@@ -229,7 +229,6 @@ class GeneralizedMorseWavelet:
             if low is None and endpoint_overlap is None:
                 if num_timepoints is None:
                     raise ValueError('When low is not provided, num_timepoints must be specified.')
-                low = num_timepoints
                 endpoint_overlap = 5
             if endpoint_overlap is not None and num_timepoints is None:
                 raise ValueError('When endpoint_overlap is set, num_timepoints must be specified.')
@@ -243,7 +242,7 @@ class GeneralizedMorseWavelet:
                 else:
                     high = np.where(nyquist_high < high, nyquist_high, high)
             if endpoint_overlap is not None:
-                endpoint_low = self._low_frequency_cutoff(r, num_timepoints)
+                endpoint_low = self._low_frequency_cutoff(endpoint_overlap, num_timepoints)
                 if low is None:
                     low = endpoint_low
                 else:

--- a/analytic_wavelet_transform_test.py
+++ b/analytic_wavelet_transform_test.py
@@ -1,0 +1,31 @@
+# analytic_wavelet_transform
+import numpy as np
+from analytic_wavelet import analytic_wavelet_transform, GeneralizedMorseWavelet, unpad, rotate, \
+    to_frequency_domain_wavelet, make_unpad_slices, masked_detrend, load_test_data, analytic_transform
+
+npg2006 = load_test_data('test_data/npg2006.mat')
+cx = np.squeeze(npg2006['cx'], axis=1)
+cv = np.squeeze(npg2006['cv'], axis=1)
+
+# mismatched length
+fs = 2 * np.pi / np.logspace(np.log10(10),np.log10(100),50)
+print(fs)
+try:
+    psi, psi_f = GeneralizedMorseWavelet(2, 4).make_wavelet(len(cx) + 10, fs)
+    analytic_wavelet_transform(np.real(cx), psi_f, np.isrealobj(psi))
+    assert(False)
+except ValueError:
+    pass
+
+# complex
+psi, psi_f = GeneralizedMorseWavelet(2, 4).make_wavelet(len(cx), fs)
+print(psi)
+wx = analytic_wavelet_transform(np.real(cx), psi_f, np.isrealobj(psi))
+wy = analytic_wavelet_transform(np.imag(cx), psi_f, np.isrealobj(psi))
+wp = analytic_wavelet_transform(cx, psi_f, np.isrealobj(psi))
+wn = analytic_wavelet_transform(np.conj(cx), psi_f, np.isrealobj(psi))
+tmat = np.array([[1, 1j], [1, -1j]]) / np.sqrt(2)
+z = np.matmul(tmat, np.concatenate([np.expand_dims(wx, 1), np.expand_dims(wy, 1)], axis=1))
+wp2, wn2 = z[:, 0, :], z[:, 1, :]
+assert(np.allclose(wp2, wp, equal_nan=True) and np.allclose(wn2, wn, equal_nan=True))
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(name='analytic_wavelet',
+      version='0.1',
+      description='A translation of J.M. Lilly\'s code for ridge and element analysis using generalized Morse wavelets into python',
+      url='https://github.com/danrsc/analytic_wavelet',
+      author='danrsc',
+      author_email='',
+      license='MIT',
+      packages=['analytic_wavelet'],
+      zip_safe=False)


### PR DESCRIPTION
Fixing log_spaced_frequencies() function to support case when low=None (which was always skipped). Also substituted parameter in the call to _low_frequency_cutoff(). endpoint_overlap (not r) is the Python variable corresponding to the Matlab variable low{1} used in https://github.com/jonathanlilly/jLab/blob/0ddd2b11b6511152dfaca8764fe202c8acd7f1d9/jWavelet/morsespace.m 